### PR TITLE
Improve TransIP domain lookup using publicsuffix eTLD handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0
 	github.com/assi010/gotransip/v6 v6.25.0
 	github.com/cert-manager/cert-manager v1.18.0
+	golang.org/x/net v0.41.0
 	k8s.io/api v0.32.5
 	k8s.io/apiextensions-apiserver v0.32.5
 	k8s.io/apimachinery v0.32.5


### PR DESCRIPTION
Good day,

While trying to implement this webhook in my cluster I ran into an issue. I was requesting a certificate for a domain of the following structure "something.example.com", this resulted in the webhook looking for a domain called "something.example.com" and wanting to create the record "_acme-challenge", instead of creating the record "_acme-challenge.something" in the domain "example.com".

This PR aims to always correctly identify the eTLD.